### PR TITLE
Sorted defines for permutation

### DIFF
--- a/include/ShaderMake/ShaderBlob.h
+++ b/include/ShaderMake/ShaderBlob.h
@@ -66,21 +66,20 @@ std::string FormatShaderNotFoundMessage(
 typedef bool (*WriteFileCallback)(const void* data, size_t size, void* context);
 
 bool WriteFileHeader(
-	WriteFileCallback write,
+    WriteFileCallback write,
     void* context
 );
 
 bool WritePermutation(
-	WriteFileCallback write,
+    WriteFileCallback write,
     void* context,
-	const std::string& permutationKey,
-	const void* binary,
-	size_t binarySize
+    const std::string& permutationKey,
+    const void* binary,
+    size_t binarySize
 );
 
 std::vector<size_t> GetSortedConstantsIndices(
-	const std::string* constants,
-    size_t numConstants
+    const std::vector<std::string>& constants
 );
 
 } // namespace ShaderMake

--- a/include/ShaderMake/ShaderBlob.h
+++ b/include/ShaderMake/ShaderBlob.h
@@ -78,4 +78,9 @@ bool WritePermutation(
 	size_t binarySize
 );
 
+std::vector<size_t> GetSortedConstantsIndices(
+	const std::string* constants,
+    size_t numConstants
+);
+
 } // namespace ShaderMake

--- a/src/ShaderBlob.cpp
+++ b/src/ShaderBlob.cpp
@@ -57,15 +57,15 @@ bool FindPermutationInBlob(const void* blob, size_t blobSize, const ShaderConsta
     blob = static_cast<const char*>(blob) + g_BlobSignatureSize;
     blobSize -= g_BlobSignatureSize;
 
-	// Making a vector of constant names to sort them
-	std::vector<std::string> constantNames((size_t)numConstants);
+    // Making a vector of constant names to sort them
+    std::vector<std::string> constantNames((size_t)numConstants);
     for (uint32_t n = 0; n < numConstants; n++)
     {
-		const ShaderConstant& constant = constants[n];
-		constantNames[n] = constant.name;
+        const ShaderConstant& constant = constants[n];
+        constantNames[n] = constant.name;
     }
-	// Sorting constant names
-	std::vector<size_t> sortedConstantsIndices = GetSortedConstantsIndices(constantNames.data(), constantNames.size());
+    // Sorting constant names
+    std::vector<size_t> sortedConstantsIndices = GetSortedConstantsIndices(constantNames.data(), constantNames.size());
 
     std::stringstream ss;
     for (uint32_t n = 0; n < numConstants; n++)
@@ -208,21 +208,19 @@ bool WritePermutation(
 
 
 std::vector<size_t> GetSortedConstantsIndices(
-    const std::string* constants,
-    size_t numConstants
+    const std::vector<std::string>& constants
 )
 {
     // Sorting defines indices to have defines sorted order. Example -> ["B", "A", "C"] -> [1, 0, 2]
-    (constants);
     // initialize original index locations
-    std::vector<size_t> sortedDefinesIndices(numConstants);
+    std::vector<size_t> sortedDefinesIndices(constants.size());
     iota(sortedDefinesIndices.begin(), sortedDefinesIndices.end(), 0);
 
     // sort indexes based on comparing defines in constants
     // using std::stable_sort instead of std::sort
     // to avoid unnecessary index re-orderings
     // when constants contains elements of equal values 
-    std::stable_sort(sortedDefinesIndices.begin(), sortedDefinesIndices.end(), [constants, numConstants](size_t i1, size_t i2) { return constants[i1] < constants[i2]; });
+    std::stable_sort(sortedDefinesIndices.begin(), sortedDefinesIndices.end(), [constants](size_t i1, size_t i2) { return constants[i1] < constants[i2]; });
 
     return sortedDefinesIndices;
 }

--- a/src/ShaderBlob.cpp
+++ b/src/ShaderBlob.cpp
@@ -24,6 +24,8 @@
 
 #include <sstream>
 #include <cstring>
+#include <numeric>      // std::iota
+#include <algorithm>    // std::sort, std::stable_sort
 
 namespace ShaderMake
 {
@@ -55,10 +57,21 @@ bool FindPermutationInBlob(const void* blob, size_t blobSize, const ShaderConsta
     blob = static_cast<const char*>(blob) + g_BlobSignatureSize;
     blobSize -= g_BlobSignatureSize;
 
+	// Making a vector of constant names to sort them
+	std::vector<std::string> constantNames((size_t)numConstants);
+    for (uint32_t n = 0; n < numConstants; n++)
+    {
+		const ShaderConstant& constant = constants[n];
+		constantNames[n] = constant.name;
+    }
+	// Sorting constant names
+	std::vector<size_t> sortedConstantsIndices = GetSortedConstantsIndices(constantNames.data(), constantNames.size());
+
     std::stringstream ss;
     for (uint32_t n = 0; n < numConstants; n++)
     {
-        const ShaderConstant& constant = constants[n];
+        size_t sortedIndex = sortedConstantsIndices[n];
+        const ShaderConstant& constant = constants[sortedIndex];
         ss << constant.name << "=" << constant.value;
         if (n + 1 < numConstants)
             ss << " ";
@@ -192,5 +205,27 @@ bool WritePermutation(
     success &= write(binary, binarySize, context);
     return success;
 }
+
+
+std::vector<size_t> GetSortedConstantsIndices(
+    const std::string* constants,
+    size_t numConstants
+)
+{
+    // Sorting defines indices to have defines sorted order. Example -> ["B", "A", "C"] -> [1, 0, 2]
+    (constants);
+    // initialize original index locations
+    std::vector<size_t> sortedDefinesIndices(numConstants);
+    iota(sortedDefinesIndices.begin(), sortedDefinesIndices.end(), 0);
+
+    // sort indexes based on comparing defines in constants
+    // using std::stable_sort instead of std::sort
+    // to avoid unnecessary index re-orderings
+    // when constants contains elements of equal values 
+    std::stable_sort(sortedDefinesIndices.begin(), sortedDefinesIndices.end(), [constants, numConstants](size_t i1, size_t i2) { return constants[i1] < constants[i2]; });
+
+    return sortedDefinesIndices;
+}
+
 
 } // namespace ShaderMake

--- a/src/ShaderMake.cpp
+++ b/src/ShaderMake.cpp
@@ -1831,13 +1831,13 @@ bool ProcessConfigLine(uint32_t lineIndex, const string& line, const fs::file_ti
 
     // Getting the sorted index of defines. While doing this, the value of defines are also get included in sorting problem
     // but it doesn't matter until two defines keys are identical which is not the case.
-	vector<size_t> definesSortedIndices = ShaderMake::GetSortedConstantsIndices(configLine.defines.data(), configLine.defines.size());
+    vector<size_t> definesSortedIndices = ShaderMake::GetSortedConstantsIndices(configLine.defines.data(), configLine.defines.size());
 
     // Concatenate define strings, i.e. to get something, like: "A=1 B=0 C"
     string combinedDefines = "";
     for (size_t i = 0; i < configLine.defines.size(); i++)
     {
-		size_t sortedIndex = definesSortedIndices[i];
+        size_t sortedIndex = definesSortedIndices[i];
         combinedDefines += configLine.defines[sortedIndex];
         if (i != configLine.defines.size() - 1 )
             combinedDefines += " ";

--- a/src/ShaderMake.cpp
+++ b/src/ShaderMake.cpp
@@ -1829,11 +1829,16 @@ bool ProcessConfigLine(uint32_t lineIndex, const string& line, const fs::file_ti
     if (g_Options.platform == DXBC && (profile == "lib" || profile == "ms" || profile == "as"))
         return true;
 
+    // Getting the sorted index of defines. While doing this, the value of defines are also get included in sorting problem
+    // but it doesn't matter until two defines keys are identical which is not the case.
+	vector<size_t> definesSortedIndices = ShaderMake::GetSortedConstantsIndices(configLine.defines.data(), configLine.defines.size());
+
     // Concatenate define strings, i.e. to get something, like: "A=1 B=0 C"
     string combinedDefines = "";
     for (size_t i = 0; i < configLine.defines.size(); i++)
     {
-        combinedDefines += configLine.defines[i];
+		size_t sortedIndex = definesSortedIndices[i];
+        combinedDefines += configLine.defines[sortedIndex];
         if (i != configLine.defines.size() - 1 )
             combinedDefines += " ";
     }


### PR DESCRIPTION
Sort defines when creating blob and when finding permutation to get the same result to matter the defines order.

having the below config for a blob:
`TestShader.hlsl -T ps -E PSMain -D PERMUTATION_A={0,1} -D PERMUTATION_B={0,1}`

if the requested defines are `{PERMUTATION_A=1, PERMUTATION_B=0}`, the desired permutation witll be returned. However, if the requested defines are `{PERMUTATION_B=1, PERMUTATION_A=0}`, it will return null since the defines order doesn't match.
Sorting defines when creating a blob, and searching in one prevents such a problem.