### PR TITLE
Upgrade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,13 @@ endif()
 cmake_dependent_option(SHADERMAKE_FIND_FXC "Find FXC in Windows SDK and populate 'SHADERMAKE_FXC_PATH' variable" ON "WIN32" OFF)
 cmake_dependent_option(SHADERMAKE_FIND_DXC "Download DXC from GitHub and populate 'SHADERMAKE_DXC_PATH' variable" ON "NOT APPLE" OFF)
 
-option(SHADERMAKE_FIND_DXC_VK "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_VK_PATH' variable (silently set to 'SHADERMAKE_DXC_PATH' if Vulkan SDK is not found)" ON)
+option(SHADERMAKE_FIND_DXC_VK "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_VK_PATH' variable" ON)
+option(SHADERMAKE_FIND_SLANG "Download Slang from GitHub and populate 'SHADERMAKE_SLANG_PATH' variable" OFF)
 option(SHADERMAKE_FIND_COMPILERS "Master switch" ON)
 
 set(SHADERMAKE_DXC_VERSION "v1.8.2502" CACHE STRING "DXC to download from 'GitHub/DirectXShaderCompiler' releases")
 set(SHADERMAKE_DXC_DATE "2025_02_20" CACHE STRING "DXC release date") # DXC releases on GitHub have this in download links :(
+set(SHADERMAKE_SLANG_VERSION "2025.9.1" CACHE STRING "Slang to download from 'GitHub/Shader-slang' releases")
 
 # Globals?
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -48,9 +50,9 @@ else()
 endif()
 
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64") OR(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64"))
-    set(WINDOWS_SYSTEM "arm64")
+    set(WINDOWS_ARCH "arm64")
 else()
-    set(WINDOWS_SYSTEM "x64")
+    set(WINDOWS_ARCH "x64")
 endif()
 
 # Find compilers
@@ -58,32 +60,65 @@ if(SHADERMAKE_FIND_COMPILERS)
     # DXC (GitHub)
     if(SHADERMAKE_FIND_DXC)
         if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-            # Linux
-            FetchContent_Declare(
-                dxc
-                DOWNLOAD_EXTRACT_TIMESTAMP 1
-                DOWNLOAD_NO_PROGRESS 1
-                URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/linux_dxc_${SHADERMAKE_DXC_DATE}.x86_64.tar.gz
-            )
-
-            FetchContent_MakeAvailable(dxc)
-
-            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc" CACHE INTERNAL "")
+            set(DXC_SUBSTRING "linux_dxc_${SHADERMAKE_DXC_DATE}.x86_64.tar.gz")
         else()
-            # Windows, ARM
-            FetchContent_Declare(
-                dxc
-                DOWNLOAD_EXTRACT_TIMESTAMP 1
-                DOWNLOAD_NO_PROGRESS 1
-                URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/dxc_${SHADERMAKE_DXC_DATE}.zip
-            )
-
-            FetchContent_MakeAvailable(dxc)
-
-            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe" CACHE INTERNAL "")
+            set(DXC_SUBSTRING "dxc_${SHADERMAKE_DXC_DATE}.zip")
         endif()
 
-        message("ShaderMake: downloading dxc ${SHADERMAKE_DXC_VERSION}...")
+        set(DXC_DOWNLOAD_LINK https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/${DXC_SUBSTRING})
+
+        FetchContent_Declare(
+            dxc
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
+            DOWNLOAD_NO_PROGRESS 1
+            URL ${DXC_DOWNLOAD_LINK}
+        )
+
+        message("ShaderMake: downloading DXC ${SHADERMAKE_DXC_VERSION}...")
+
+        FetchContent_MakeAvailable(dxc)
+
+        if(WIN32)
+            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_ARCH}/dxc.exe" CACHE INTERNAL "")
+        else()
+            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc" CACHE INTERNAL "")
+        endif()
+    endif()
+
+    # Slang (GitHub)
+    if(SHADERMAKE_FIND_SLANG)
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+            set(SLANG_SUBSTRING "-linux")
+        elseif(APPLE)
+            set(SLANG_SUBSTRING "-macos")
+        else()
+            set(SLANG_SUBSTRING "-windows")
+        endif()
+
+        if((CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64") OR(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64"))
+            set(SLANG_SUBSTRING "${SLANG_SUBSTRING}-aarch64")
+        else()
+            set(SLANG_SUBSTRING "${SLANG_SUBSTRING}-x86_64")
+        endif()
+
+        set(SLANG_DOWNLOAD_LINK https://github.com/shader-slang/slang/releases/download/v${SHADERMAKE_SLANG_VERSION}/slang-${SHADERMAKE_SLANG_VERSION}${SLANG_SUBSTRING}.zip)
+
+        FetchContent_Declare(
+            slang
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
+            DOWNLOAD_NO_PROGRESS 1
+            URL ${SLANG_DOWNLOAD_LINK}
+        )
+
+        message("ShaderMake: downloading Slang ${SHADERMAKE_SLANG_VERSION}...")
+
+        FetchContent_MakeAvailable(slang)
+
+        if(WIN32)
+            set(SHADERMAKE_SLANG_PATH "${slang_SOURCE_DIR}/bin/slangc.exe" CACHE INTERNAL "")
+        else()
+            set(SHADERMAKE_SLANG_PATH "${slang_SOURCE_DIR}/bin/slangc" CACHE INTERNAL "")
+        endif()
     endif()
 
     # DXC (Vulkan SDK)
@@ -116,7 +151,7 @@ if(SHADERMAKE_FIND_COMPILERS)
         endif()
 
         get_filename_component(WINDOWS_SDK_ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
-        set(WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/${WINDOWS_SYSTEM}")
+        set(WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/${WINDOWS_ARCH}")
 
         find_program(SHADERMAKE_FXC_PATH "${WINDOWS_SDK_BIN}/fxc")
     endif()
@@ -173,3 +208,4 @@ endif()
 message("ShaderMake: SHADERMAKE_FXC_PATH = '${SHADERMAKE_FXC_PATH}'")
 message("ShaderMake: SHADERMAKE_DXC_PATH = '${SHADERMAKE_DXC_PATH}'")
 message("ShaderMake: SHADERMAKE_DXC_VK_PATH = '${SHADERMAKE_DXC_VK_PATH}'")
+message("ShaderMake: SHADERMAKE_SLANG_PATH = '${SHADERMAKE_SLANG_PATH}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ else()
     set(SHADERMAKE_BIN_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin" CACHE STRING "")
 endif()
 
-cmake_dependent_option(SHADERMAKE_FIND_FXC "Find FXC in Windows SDK and populate 'SHADERMAKE_FXC_PATH' (and 'FXC_PATH') variables" ON "WIN32" OFF)
-cmake_dependent_option(SHADERMAKE_FIND_DXC "Download DXC from GitHub and populate 'SHADERMAKE_DXC_PATH' (and 'DXC_PATH') variables" ON "NOT APPLE" OFF)
+cmake_dependent_option(SHADERMAKE_FIND_FXC "Find FXC in Windows SDK and populate 'SHADERMAKE_FXC_PATH' variable" ON "WIN32" OFF)
+cmake_dependent_option(SHADERMAKE_FIND_DXC "Download DXC from GitHub and populate 'SHADERMAKE_DXC_PATH' variable" ON "NOT APPLE" OFF)
 
-option(SHADERMAKE_FIND_DXC_SPIRV "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_SPIRV_PATH' (and 'DXC_SPIRV_PATH') variables" ON)
+option(SHADERMAKE_FIND_DXC_VK "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_VK_PATH' variable (silently set to 'SHADERMAKE_DXC_PATH' if Vulkan SDK is not found)" ON)
 option(SHADERMAKE_FIND_COMPILERS "Master switch" ON)
 
 set(SHADERMAKE_DXC_VERSION "v1.8.2502" CACHE STRING "DXC to download from 'GitHub/DirectXShaderCompiler' releases")
@@ -87,17 +87,22 @@ if(SHADERMAKE_FIND_COMPILERS)
     endif()
 
     # DXC (Vulkan SDK)
-    if(SHADERMAKE_FIND_DXC_SPIRV)
+    if(SHADERMAKE_FIND_DXC_VK)
         if(WIN32)
-            find_program(SHADERMAKE_DXC_SPIRV_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
+            find_program(SHADERMAKE_DXC_VK_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
         else()
-            find_program(SHADERMAKE_DXC_SPIRV_PATH "dxc")
+            find_program(SHADERMAKE_DXC_VK_PATH "dxc")
         endif()
 
-        if(NOT SHADERMAKE_DXC_SPIRV_PATH)
-            message("ShaderMake: Vulkan SDK is not installed")
-            set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
+        # Soft-fallback to a valid path
+        if(NOT SHADERMAKE_DXC_PATH AND SHADERMAKE_DXC_VK_PATH)
+            set(SHADERMAKE_DXC_PATH ${SHADERMAKE_DXC_VK_PATH} CACHE INTERNAL "")
         endif()
+    endif()
+
+    # Soft-fallback to a valid path
+    if(NOT SHADERMAKE_DXC_VK_PATH AND SHADERMAKE_DXC_PATH)
+        set(SHADERMAKE_DXC_VK_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
     endif()
 
     # FXC (Windows SDK)
@@ -167,9 +172,4 @@ endif()
 # Done
 message("ShaderMake: SHADERMAKE_FXC_PATH = '${SHADERMAKE_FXC_PATH}'")
 message("ShaderMake: SHADERMAKE_DXC_PATH = '${SHADERMAKE_DXC_PATH}'")
-message("ShaderMake: SHADERMAKE_DXC_SPIRV_PATH = '${SHADERMAKE_DXC_SPIRV_PATH}'")
-
-# Compatibility names # TODO: remove
-set(FXC_PATH ${SHADERMAKE_FXC_PATH} CACHE INTERNAL "")
-set(DXC_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
-set(DXC_SPIRV_PATH ${SHADERMAKE_DXC_SPIRV_PATH} CACHE INTERNAL "")
+message("ShaderMake: SHADERMAKE_DXC_VK_PATH = '${SHADERMAKE_DXC_VK_PATH}'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ if(SHADERMAKE_FIND_DXC)
 
         FetchContent_MakeAvailable(dxc)
 
-        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc")
+        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc" CACHE INTERNAL "")
     else()
         # Windows, ARM
         FetchContent_Declare(
@@ -77,7 +77,7 @@ if(SHADERMAKE_FIND_DXC)
 
         FetchContent_MakeAvailable(dxc)
 
-        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe")
+        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe" CACHE INTERNAL "")
     endif()
 
     message("ShaderMake: downloading dxc ${SHADERMAKE_DXC_VERSION}...")
@@ -93,7 +93,7 @@ if(SHADERMAKE_FIND_DXC_SPIRV)
 
     if(NOT SHADERMAKE_DXC_SPIRV_PATH)
         message("ShaderMake: Vulkan SDK is not installed")
-        set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH})
+        set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
     endif()
 endif()
 
@@ -168,6 +168,6 @@ message("ShaderMake: SHADERMAKE_DXC_PATH = '${SHADERMAKE_DXC_PATH}'")
 message("ShaderMake: SHADERMAKE_DXC_SPIRV_PATH = '${SHADERMAKE_DXC_SPIRV_PATH}'")
 
 # Compatibility names # TODO: remove
-set(FXC_PATH ${SHADERMAKE_FXC_PATH})
-set(DXC_PATH ${SHADERMAKE_DXC_PATH})
-set(DXC_SPIRV_PATH ${SHADERMAKE_DXC_SPIRV_PATH})
+set(FXC_PATH ${SHADERMAKE_FXC_PATH} CACHE INTERNAL "")
+set(DXC_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
+set(DXC_SPIRV_PATH ${SHADERMAKE_DXC_SPIRV_PATH} CACHE INTERNAL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 if(SHADERMAKE_FIND_COMPILERS)
     # DXC (GitHub)
     if(SHADERMAKE_FIND_DXC)
-        if((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"))
+        if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             # Linux
             FetchContent_Declare(
                 dxc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,167 +1,173 @@
-cmake_minimum_required (VERSION 3.15)
+cmake_minimum_required(VERSION 3.15)
+
+include(FetchContent)
+include(CMakeDependentOption)
+
+project(ShaderMake LANGUAGES C CXX)
 
 # Is submodule?
-if (${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-    set (SHADERMAKE_IS_SUBMODULE OFF)
-else ()
-    set (SHADERMAKE_IS_SUBMODULE ON)
-endif ()
-
-# Cached
-if (SHADERMAKE_IS_SUBMODULE)
-    set (SHADERMAKE_BIN_OUTPUT_PATH "" CACHE STRING "")
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+    set(SHADERMAKE_IS_SUBMODULE OFF)
 else()
-    set (CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "")
-    set (SHADERMAKE_BIN_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin" CACHE STRING "")
+    set(SHADERMAKE_IS_SUBMODULE ON)
 endif()
 
-set (SHADERMAKE_SEARCH_FOR_COMPILERS ${SHADERMAKE_IS_SUBMODULE} CACHE BOOL "Toggles whether to search for dxc.exe and fxc.exe")
-option (SHADERMAKE_FIND_FXC "Toggles whether to search for FXC" ON)
-option (SHADERMAKE_FIND_DXC "Toggles whether to search for DXC for DXIL" ON)
-option (SHADERMAKE_FIND_DXC_SPIRV "Toggles whether to search for DXC for SPIR-V" ON)
+# Cached
+if(SHADERMAKE_IS_SUBMODULE)
+    set(SHADERMAKE_BIN_OUTPUT_PATH "" CACHE STRING "")
+else()
+    set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "")
+    set(SHADERMAKE_BIN_OUTPUT_PATH "${CMAKE_SOURCE_DIR}/bin" CACHE STRING "")
+endif()
 
-project (ShaderMake LANGUAGES C CXX)
+cmake_dependent_option(SHADERMAKE_FIND_FXC "Find FXC in Windows SDK and populate 'SHADERMAKE_FXC_PATH' (and 'FXC_PATH') variables" ON "WIN32" OFF)
+cmake_dependent_option(SHADERMAKE_FIND_DXC "Download DXC from GitHub and populate 'SHADERMAKE_DXC_PATH' (and 'DXC_PATH') variables" ON "NOT APPLE" OFF)
+
+option(SHADERMAKE_FIND_DXC_SPIRV "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_SPIRV_PATH' (and 'DXC_SPIRV_PATH') variables" ON)
+
+set(SHADERMAKE_DXC_VERSION "v1.8.2502" CACHE STRING "DXC to download from 'GitHub/DirectXShaderCompiler' releases")
+set(SHADERMAKE_DXC_DATE "2025_02_20" CACHE STRING "DXC release date") # DXC releases on GitHub have this in download links :(
 
 # Globals?
-set_property (GLOBAL PROPERTY USE_FOLDERS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
-set (CMAKE_CXX_STANDARD 17)
-set (CMAKE_CXX_STANDARD_REQUIRED ON)
-set (CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
 
-if (MSVC)
-    # Test the Windows SDK version to make sure that we can compile ShaderMake.
-    # ShaderMake uses some relatively new APIs for DXC, and there's no straightforward way to test
-    # if they're declared in the SDK headers. So, test it here to prevent obscure errors.
-    set(_MIN_WINDOWS_SDK_VERSION_BUILD 20348)
-    string(REGEX MATCH "^10\\.0\\.([0-9]+)\\.[0-9]+$" _WINDOWS_SDK_VERSION "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
-    if (_WINDOWS_SDK_VERSION)
-        set(_WINDOWS_SDK_VERSION_BUILD "${CMAKE_MATCH_1}")
-        if (_WINDOWS_SDK_VERSION_BUILD LESS _MIN_WINDOWS_SDK_VERSION_BUILD)
-            message(SEND_ERROR "ShaderMake requires Windows SDK version at least 10.0.${_MIN_WINDOWS_SDK_VERSION_BUILD}.0.")
-        endif()
+# Compile options
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(COMPILE_OPTIONS -Wextra)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(COMPILE_OPTIONS -Wextra)
+elseif(MSVC)
+    set(COMPILE_OPTIONS /W4 /WX)
+else()
+    message(WARNING "ShaderMake: Unknown compiler!")
+endif()
+
+if((CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64") OR(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64"))
+    set(WINDOWS_SYSTEM "arm64")
+else()
+    set(WINDOWS_SYSTEM "x64")
+endif()
+
+# DXC (GitHub)
+if(SHADERMAKE_FIND_DXC)
+    if((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"))
+        # Linux
+        FetchContent_Declare(
+            dxc
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
+            DOWNLOAD_NO_PROGRESS 1
+            URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/linux_dxc_${SHADERMAKE_DXC_DATE}.x86_64.tar.gz
+        )
+
+        FetchContent_MakeAvailable(dxc)
+
+        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc")
     else()
-        message(WARNING "ShaderMake: Unknown Windows SDK version '${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}', errors may occur during build.")
+        # Windows, ARM
+        FetchContent_Declare(
+            dxc
+            DOWNLOAD_EXTRACT_TIMESTAMP 1
+            DOWNLOAD_NO_PROGRESS 1
+            URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/dxc_${SHADERMAKE_DXC_DATE}.zip
+        )
+
+        FetchContent_MakeAvailable(dxc)
+
+        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe")
+    endif()
+
+    message("ShaderMake: downloading dxc ${SHADERMAKE_DXC_VERSION}...")
+endif()
+
+# DXC (Vulkan SDK)
+if(SHADERMAKE_FIND_DXC_SPIRV)
+    if(WIN32)
+        find_program(SHADERMAKE_DXC_SPIRV_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
+    else()
+        find_program(SHADERMAKE_DXC_SPIRV_PATH "dxc")
+    endif()
+
+    if(NOT SHADERMAKE_DXC_SPIRV_PATH)
+        message("ShaderMake: Vulkan SDK is not installed")
+        set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH})
     endif()
 endif()
 
-# Compile options
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-  set (SIMD -msse4.1)
-endif ()
+# FXC
+if(SHADERMAKE_FIND_FXC)
+    # Find Windows SDK
+    if(DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+        set(WINDOWS_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+    elseif(DEFINED ENV{WindowsSDKLibVersion})
+        string(REGEX REPLACE "\\\\$" "" WINDOWS_SDK_VERSION "$ENV{WindowsSDKLibVersion}")
+    else()
+        message(FATAL_ERROR "ShaderMake: WindowsSDK is not installed (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is not defined; WindowsSDKLibVersion is '$ENV{WindowsSDKLibVersion}')!")
+    endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set (COMPILE_OPTIONS ${SIMD} -Wextra)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    set (COMPILE_OPTIONS ${SIMD} -Wextra)
-elseif (MSVC)
-    set (COMPILE_OPTIONS /W4 /WX /wd4324)
-else ()
-    message (WARNING "Unknown compiler!")
-endif ()
+    get_filename_component(WINDOWS_SDK_ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
+    set(WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/${WINDOWS_SYSTEM}")
+
+    # Find FXC
+    find_program(SHADERMAKE_FXC_PATH "${WINDOWS_SDK_BIN}/fxc")
+endif()
 
 # Library with blob read and write functions for use by client projects
-add_library (ShaderMakeBlob STATIC
-    include/ShaderMake/ShaderBlob.h
-    src/ShaderBlob.cpp
+add_library(ShaderMakeBlob STATIC
+    "include/ShaderMake/ShaderBlob.h"
+    "src/ShaderBlob.cpp"
 )
-target_include_directories (ShaderMakeBlob PUBLIC "include")
-target_compile_options (ShaderMakeBlob PRIVATE ${COMPILE_OPTIONS})
-set_target_properties (ShaderMakeBlob PROPERTIES 
+target_include_directories(ShaderMakeBlob PUBLIC "include")
+target_compile_options(ShaderMakeBlob PRIVATE ${COMPILE_OPTIONS})
+set_target_properties(ShaderMakeBlob PROPERTIES
     FOLDER ShaderMake
     POSITION_INDEPENDENT_CODE ON
 )
 
 # ShaderMake executable
-add_executable (ShaderMake
-    src/argparse.c
-    src/argparse.h
-    src/ShaderMake.cpp 
+add_executable(ShaderMake
+    "src/argparse.c"
+    "src/argparse.h"
+    "src/ShaderMake.cpp"
 )
-target_compile_options (ShaderMake PRIVATE ${COMPILE_OPTIONS})
+target_compile_options(ShaderMake PRIVATE ${COMPILE_OPTIONS})
 
-# Set the output paths if SHADERMAKE_BIN_OUTPUT_PATH is specified.
-# If not, use default CMake paths.
-if (SHADERMAKE_BIN_OUTPUT_PATH)
-    set_target_properties (ShaderMake PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY                "${SHADERMAKE_BIN_OUTPUT_PATH}/$<CONFIG>"
-        RUNTIME_OUTPUT_DIRECTORY_DEBUG          "${SHADERMAKE_BIN_OUTPUT_PATH}/Debug"
-        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL     "${SHADERMAKE_BIN_OUTPUT_PATH}/MinSizeRel"
-        RUNTIME_OUTPUT_DIRECTORY_RELEASE        "${SHADERMAKE_BIN_OUTPUT_PATH}/Release"
+if(SHADERMAKE_BIN_OUTPUT_PATH)
+    set_target_properties(ShaderMake PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${SHADERMAKE_BIN_OUTPUT_PATH}/$<CONFIG>"
+        RUNTIME_OUTPUT_DIRECTORY_DEBUG "${SHADERMAKE_BIN_OUTPUT_PATH}/Debug"
+        RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${SHADERMAKE_BIN_OUTPUT_PATH}/MinSizeRel"
+        RUNTIME_OUTPUT_DIRECTORY_RELEASE "${SHADERMAKE_BIN_OUTPUT_PATH}/Release"
         RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${SHADERMAKE_BIN_OUTPUT_PATH}/RelWithDebInfo"
     )
 endif()
 
-set_property (DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ShaderMake)
-set_property (TARGET ShaderMake PROPERTY FOLDER ShaderMake)
-target_link_libraries (ShaderMake ShaderMakeBlob)
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ShaderMake)
+set_property(TARGET ShaderMake PROPERTY FOLDER ShaderMake)
+target_link_libraries(ShaderMake ShaderMakeBlob)
 
-if (MSVC)
-    target_compile_definitions (ShaderMake PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX _CRT_SECURE_NO_WARNINGS)
-    target_link_options (ShaderMake PRIVATE "/DELAYLOAD:dxcompiler.dll")
-    target_link_libraries (ShaderMake d3dcompiler dxcompiler delayimp)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR APPLE)
-    target_link_libraries (ShaderMake pthread)
-else ()
-    target_link_libraries (ShaderMake stdc++fs pthread)
-endif ()
-
-if (SHADERMAKE_SEARCH_FOR_COMPILERS)
-    # Finding FXC/DXC
-    if (WIN32)
-        if (SHADERMAKE_FIND_FXC OR SHADERMAKE_FIND_DXC)
-            # On Windows - FXC and DXC are part of WindowsSDK and there's also DXC in VulkanSDK which supports SPIR-V
-            if (DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
-                set (WINDOWS_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
-            elseif (DEFINED ENV{WindowsSDKLibVersion})
-                string (REGEX REPLACE "\\\\$" "" WINDOWS_SDK_VERSION "$ENV{WindowsSDKLibVersion}")
-            else ()
-                message (FATAL_ERROR "WindowsSDK is not installed (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is not defined; WindowsSDKLibVersion is '$ENV{WindowsSDKLibVersion}')!")
-            endif ()
-
-            get_filename_component (WINDOWS_SDK_ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
-            set (WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/x64")
-
-            if (SHADERMAKE_FIND_FXC)
-                find_program (FXC_PATH "${WINDOWS_SDK_BIN}/fxc")
-                if (NOT FXC_PATH)
-                    message (FATAL_ERROR "Can't find FXC in WindowsSDK: ${WINDOWS_SDK_BIN}")
-                endif ()
-            endif()
-
-            if (SHADERMAKE_FIND_DXC)
-                find_program (DXC_PATH "${WINDOWS_SDK_BIN}/dxc")
-                if (NOT DXC_PATH)
-                    message (FATAL_ERROR "Can't find DXC in WindowsSDK: ${WINDOWS_SDK_BIN}")
-                endif ()
-            endif()
-        endif()
-
-        if (SHADERMAKE_FIND_DXC_SPIRV)
-            find_program (DXC_SPIRV_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
-        endif()
-    else ()
-        if (SHADERMAKE_FIND_DXC_SPIRV)
-            # On Linux - VulkanSDK does not set VULKAN_SDK, but DXC can be called directly
-            find_program (DXC_SPIRV_PATH "dxc")
-        endif()
-    endif ()
-
-    if (SHADERMAKE_FIND_DXC_SPIRV AND NOT DXC_SPIRV_PATH)
-        find_program (DXC_SPIRV_PATH "dxc" "${DXC_CUSTOM_PATH}")
-    endif ()
-
-    if (SHADERMAKE_FIND_DXC_SPIRV AND NOT DXC_SPIRV_PATH)
-        message (FATAL_ERROR "Can't find DXC: Specify custom path using 'DXC_CUSTOM_PATH' parameter or install VulkanSDK!")
-    endif ()
-
-    if (SHADERMAKE_FIND_FXC)
-        message (STATUS "Setting 'FXC_PATH' to '${FXC_PATH}'")
-    endif()
-    if (SHADERMAKE_FIND_DXC)
-        message (STATUS "Setting 'DXC_PATH' to '${DXC_PATH}'")
-    endif()
-    if (SHADERMAKE_FIND_DXC_SPIRV)
-        message (STATUS "Setting 'DXC_SPIRV_PATH' to '${DXC_SPIRV_PATH}'")
-    endif()
+if(WIN32)
+    target_compile_definitions(ShaderMake PRIVATE
+        WIN32_LEAN_AND_MEAN
+        NOMINMAX
+        _CRT_SECURE_NO_WARNINGS
+    )
+    target_link_libraries(ShaderMake d3dcompiler)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR APPLE)
+    target_link_libraries(ShaderMake pthread)
+else()
+    target_link_libraries(ShaderMake stdc++fs pthread)
 endif()
+
+# Done
+message("ShaderMake: SHADERMAKE_FXC_PATH = '${SHADERMAKE_FXC_PATH}'")
+message("ShaderMake: SHADERMAKE_DXC_PATH = '${SHADERMAKE_DXC_PATH}'")
+message("ShaderMake: SHADERMAKE_DXC_SPIRV_PATH = '${SHADERMAKE_DXC_SPIRV_PATH}'")
+
+# Compatibility names # TODO: remove
+set(FXC_PATH ${SHADERMAKE_FXC_PATH})
+set(DXC_PATH ${SHADERMAKE_DXC_PATH})
+set(DXC_SPIRV_PATH ${SHADERMAKE_DXC_SPIRV_PATH})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ cmake_dependent_option(SHADERMAKE_FIND_FXC "Find FXC in Windows SDK and populate
 cmake_dependent_option(SHADERMAKE_FIND_DXC "Download DXC from GitHub and populate 'SHADERMAKE_DXC_PATH' (and 'DXC_PATH') variables" ON "NOT APPLE" OFF)
 
 option(SHADERMAKE_FIND_DXC_SPIRV "Find DXC in Vulkan SDK and populate 'SHADERMAKE_DXC_SPIRV_PATH' (and 'DXC_SPIRV_PATH') variables" ON)
+option(SHADERMAKE_FIND_COMPILERS "Master switch" ON)
 
 set(SHADERMAKE_DXC_VERSION "v1.8.2502" CACHE STRING "DXC to download from 'GitHub/DirectXShaderCompiler' releases")
 set(SHADERMAKE_DXC_DATE "2025_02_20" CACHE STRING "DXC release date") # DXC releases on GitHub have this in download links :(
@@ -52,70 +53,71 @@ else()
     set(WINDOWS_SYSTEM "x64")
 endif()
 
-# DXC (GitHub)
-if(SHADERMAKE_FIND_DXC)
-    if((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"))
-        # Linux
-        FetchContent_Declare(
-            dxc
-            DOWNLOAD_EXTRACT_TIMESTAMP 1
-            DOWNLOAD_NO_PROGRESS 1
-            URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/linux_dxc_${SHADERMAKE_DXC_DATE}.x86_64.tar.gz
-        )
+# Find compilers
+if(SHADERMAKE_FIND_COMPILERS)
+    # DXC (GitHub)
+    if(SHADERMAKE_FIND_DXC)
+        if((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64"))
+            # Linux
+            FetchContent_Declare(
+                dxc
+                DOWNLOAD_EXTRACT_TIMESTAMP 1
+                DOWNLOAD_NO_PROGRESS 1
+                URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/linux_dxc_${SHADERMAKE_DXC_DATE}.x86_64.tar.gz
+            )
 
-        FetchContent_MakeAvailable(dxc)
+            FetchContent_MakeAvailable(dxc)
 
-        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc" CACHE INTERNAL "")
-    else()
-        # Windows, ARM
-        FetchContent_Declare(
-            dxc
-            DOWNLOAD_EXTRACT_TIMESTAMP 1
-            DOWNLOAD_NO_PROGRESS 1
-            URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/dxc_${SHADERMAKE_DXC_DATE}.zip
-        )
+            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/dxc" CACHE INTERNAL "")
+        else()
+            # Windows, ARM
+            FetchContent_Declare(
+                dxc
+                DOWNLOAD_EXTRACT_TIMESTAMP 1
+                DOWNLOAD_NO_PROGRESS 1
+                URL https://github.com/microsoft/DirectXShaderCompiler/releases/download/${SHADERMAKE_DXC_VERSION}/dxc_${SHADERMAKE_DXC_DATE}.zip
+            )
 
-        FetchContent_MakeAvailable(dxc)
+            FetchContent_MakeAvailable(dxc)
 
-        set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe" CACHE INTERNAL "")
+            set(SHADERMAKE_DXC_PATH "${dxc_SOURCE_DIR}/bin/${WINDOWS_SYSTEM}/dxc.exe" CACHE INTERNAL "")
+        endif()
+
+        message("ShaderMake: downloading dxc ${SHADERMAKE_DXC_VERSION}...")
     endif()
 
-    message("ShaderMake: downloading dxc ${SHADERMAKE_DXC_VERSION}...")
+    # DXC (Vulkan SDK)
+    if(SHADERMAKE_FIND_DXC_SPIRV)
+        if(WIN32)
+            find_program(SHADERMAKE_DXC_SPIRV_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
+        else()
+            find_program(SHADERMAKE_DXC_SPIRV_PATH "dxc")
+        endif()
+
+        if(NOT SHADERMAKE_DXC_SPIRV_PATH)
+            message("ShaderMake: Vulkan SDK is not installed")
+            set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
+        endif()
+    endif()
+
+    # FXC (Windows SDK)
+    if(SHADERMAKE_FIND_FXC)
+        if(DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+            set(WINDOWS_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+        elseif(DEFINED ENV{WindowsSDKLibVersion})
+            string(REGEX REPLACE "\\\\$" "" WINDOWS_SDK_VERSION "$ENV{WindowsSDKLibVersion}")
+        else()
+            message(FATAL_ERROR "ShaderMake: WindowsSDK is not installed (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is not defined; WindowsSDKLibVersion is '$ENV{WindowsSDKLibVersion}')!")
+        endif()
+
+        get_filename_component(WINDOWS_SDK_ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
+        set(WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/${WINDOWS_SYSTEM}")
+
+        find_program(SHADERMAKE_FXC_PATH "${WINDOWS_SDK_BIN}/fxc")
+    endif()
 endif()
 
-# DXC (Vulkan SDK)
-if(SHADERMAKE_FIND_DXC_SPIRV)
-    if(WIN32)
-        find_program(SHADERMAKE_DXC_SPIRV_PATH "$ENV{VULKAN_SDK}/Bin/dxc")
-    else()
-        find_program(SHADERMAKE_DXC_SPIRV_PATH "dxc")
-    endif()
-
-    if(NOT SHADERMAKE_DXC_SPIRV_PATH)
-        message("ShaderMake: Vulkan SDK is not installed")
-        set(SHADERMAKE_DXC_SPIRV_PATH ${SHADERMAKE_DXC_PATH} CACHE INTERNAL "")
-    endif()
-endif()
-
-# FXC
-if(SHADERMAKE_FIND_FXC)
-    # Find Windows SDK
-    if(DEFINED CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
-        set(WINDOWS_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
-    elseif(DEFINED ENV{WindowsSDKLibVersion})
-        string(REGEX REPLACE "\\\\$" "" WINDOWS_SDK_VERSION "$ENV{WindowsSDKLibVersion}")
-    else()
-        message(FATAL_ERROR "ShaderMake: WindowsSDK is not installed (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION is not defined; WindowsSDKLibVersion is '$ENV{WindowsSDKLibVersion}')!")
-    endif()
-
-    get_filename_component(WINDOWS_SDK_ROOT "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
-    set(WINDOWS_SDK_BIN "${WINDOWS_SDK_ROOT}/bin/${WINDOWS_SDK_VERSION}/${WINDOWS_SYSTEM}")
-
-    # Find FXC
-    find_program(SHADERMAKE_FXC_PATH "${WINDOWS_SDK_BIN}/fxc")
-endif()
-
-# Library with blob read and write functions for use by client projects
+# ShaderMakeBlob
 add_library(ShaderMakeBlob STATIC
     "include/ShaderMake/ShaderBlob.h"
     "src/ShaderBlob.cpp"
@@ -127,7 +129,7 @@ set_target_properties(ShaderMakeBlob PROPERTIES
     POSITION_INDEPENDENT_CODE ON
 )
 
-# ShaderMake executable
+# ShaderMake
 add_executable(ShaderMake
     "src/argparse.c"
     "src/argparse.h"
@@ -156,7 +158,7 @@ if(WIN32)
         _CRT_SECURE_NO_WARNINGS
     )
     target_link_libraries(ShaderMake d3dcompiler)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR APPLE)
+elseif(APPLE)
     target_link_libraries(ShaderMake pthread)
 else()
     target_link_libraries(ShaderMake stdc++fs pthread)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ ShaderMake is a frond-end tool for batch multi-threaded shader compilation devel
 
 Features:
 
-- Generates DXBC, DXIL and SPIR-V code.
-- Outputs results in 3 formats: native binary, header file, and a [binary blob](#user-content-shader-blob-api) containing all permutations for a given shader.
+- Generates DXBC, DXIL and SPIR-V code;
+- Output formats: a native binary, a header file, and a binary or header [blob](#user-content-shader-blob) (containing all permutations for a givan input shader file);
 - Minimizes the number of re-compilation tasks by tracking file modification times and include trees.
 
 During project deployment, the *CMake* script automatically downloads/searches for `fxc` and `dxc` and sets these variables:
@@ -114,12 +114,6 @@ Additionally, the config file parser supports:
 - `#else`
 - `#endif`
 
-## Shader blob API
+## Shader blob
 
-When the `--binaryBlob` or `--headerBlob` command line arguments are specified, ShaderMake will package multiple permutations for the same shader into a single "blob" file. These files use a custom format that is somewhat similar to regular TAR.
-
-ShaderMake provides a small library with parsing functions to use these blob files in applications. This library can be statically linked with an application by including ShaderMake as a git submodule and linking the `ShaderMakeBlob` target to your application:
-
-    target_link_libraries(my_target PRIVATE ShaderMakeBlob)
-
-Then include `<ShaderMake/ShaderBlob.h>` and use the `ShaderMake::FindPermutationInBlob` to locate a specific shader version in a blob. If that is unsuccessful, the `ShaderMake::EnumeratePermutationsInBlob` and/or `ShaderMake::FormatShaderNotFoundMessage` functions can help you provide a helpful error message to the user.
+When the `--binaryBlob` or `--headerBlob` command line arguments are specified, ShaderMake will package multiple permutations for the same shader into a single "blob" file with a custom format. ShaderMake provides a small library with parsing functions to use these blob files. This library can be statically linked with an application by including `ShaderMake` into the project and linking `ShaderMakeBlob` target to your application. Then include `<ShaderMake/ShaderBlob.h>` and use the `ShaderMake::FindPermutationInBlob()` to locate a specific shader permutation in a blob. If that is unsuccessful, `ShaderMake::EnumeratePermutationsInBlob()` and/or `ShaderMake::FormatShaderNotFoundMessage()` functions can help to provide a meaningful error message to the user.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Features:
 
 During project deployment, the *CMake* script automatically downloads/searches for `fxc` and `dxc` and sets these variables:
 
-- `SHADERMAKE_FXC_PATH` (and `FXC_PATH`) - path to `fxc` from *Windows SDK*
-- `SHADERMAKE_DXC_PATH` (and `SHADERMAKE_DXC_PATH`) - path to `dxc` from *GitHub*
-- `SHADERMAKE_DXC_SPIRV_PATH` (and `SHADERMAKE_DXC_SPIRV_PATH`) - path to `dxc` from *Vulkan SDK* (with soft fallback to `dxc` from GitHub if requested but *Vulkan SDK* is not found)
+- `SHADERMAKE_FXC_PATH` - path to `fxc` from *Windows SDK*
+- `SHADERMAKE_DXC_PATH` - path to `dxc` downloaded from *GitHub*
+- `SHADERMAKE_DXC_VK_PATH` - path to `dxc` from *Vulkan SDK* (with soft fallback to `dxc` from GitHub if requested but *Vulkan SDK* is not found)
 
 ## Command line options
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,26 @@
 
 [![Build Status](https://github.com/NVIDIA-RTX/ShaderMake/actions/workflows/build.yml/badge.svg)](https://github.com/NVIDIA-RTX/ShaderMake/actions/workflows/build.yml)
 
-ShaderMake is a frond-end tool for batch multi-threaded shader compilation developed by NVIDIA DevTech. It is compatible with Microsoft FXC and DXC compilers by calling them via API functions or executing them through command line, and with [Slang](https://github.com/shader-slang/slang) through command line only.
+ShaderMake is a frond-end tool for batch multi-threaded shader compilation developed by NVIDIA DevTech. It is compatible with Microsoft *FXC* and *DXC* compilers by calling them via API functions or executing them through command line, and with [Slang](https://github.com/shader-slang/slang) through command line only.
 
 Features:
 
-- Generates DXBC, DXIL and SPIR-V code;
+- Generates *DXBC*, *DXIL* *SPIRV* and any produced by *Slang*;
 - Output formats: a native binary, a header file, and a binary or header [blob](#user-content-shader-blob) (containing all permutations for a givan input shader file);
 - Minimizes the number of re-compilation tasks by tracking file modification times and include trees.
 
-During project deployment, the *CMake* script automatically downloads/searches for `fxc` and `dxc` and sets these variables:
+*CMake* options:
 
-- `SHADERMAKE_FXC_PATH` - path to `fxc` from *Windows SDK*
-- `SHADERMAKE_DXC_PATH` - path to `dxc` downloaded from *GitHub*
-- `SHADERMAKE_DXC_VK_PATH` - path to `dxc` from *Vulkan SDK* (with soft fallback to `dxc` from GitHub if requested but *Vulkan SDK* is not found)
+- `SHADERMAKE_FIND_FXC` - find *FXC* in installed [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) and populate `SHADERMAKE_FXC_PATH`
+- `SHADERMAKE_FIND_DXC` -  download [DXC]((https://github.com/microsoft/DirectXShaderCompiler)) from *GitHub* and populate `SHADERMAKE_DXC_PATH`
+- `SHADERMAKE_FIND_DXC_VK` - find *DXC* in installed [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/) and populate `SHADERMAKE_DXC_VK_PATH` (this is the only way to get *DXC* on *MacOS* currently)
+- `SHADERMAKE_FIND_SLANG` - download [Slang](https://github.com/shader-slang/slang) from *GitHub* and populate `SHADERMAKE_SLANG_PATH`
+- `SHADERMAKE_FIND_COMPILERS` - master switch
+- `SHADERMAKE_DXC_VERSION` - *DXC* to download from *GitHub/DirectXShaderCompiler* releases
+- `SHADERMAKE_DXC_DATE` - *DXC* release date (unfortunately present in the download links)
+- `SHADERMAKE_SLANG_VERSION` - *Slang* to download from *GitHub/Shader-slang/slang* releases
+
+If one of `SHADERMAKE_DXC_PATH` or `SHADERMAKE_DXC_VK_PATH` left empty during deployment, it will be set to the valid one (both support *DXIL* and *SPIRV* code generation).
 
 ## Command line options
 
@@ -29,28 +36,28 @@ ShaderMake.exe -p {DXBC|DXIL|SPIRV} --binary [--header --blob] -c "path/to/confi
 ```
 
 Required options:
-- `-p, --platform` (string) - DXBC, DXIL or SPIRV
+- `-p, --platform` (string) - *DXBC*, *DXIL* or *SPIRV*
 - `-c, --config` (string) - Configuration file with the list of shaders to compile
 - `-o, --out` (string) - Output directory
 - `-b, --binary` - Output binary files
 - `-h, --header` - Output header files
 - `-B, --binaryBlob` - Output binary blob files
 - `-H, --headerBlob` - Output header blob files
-- `--compiler` (string) - Path to a FXC/DXC/Slang compiler
+- `--compiler` (string) - Path to a *FXC/DXC/Slang* compiler
 
 Compiler settings:
-- `-m, --shaderModel` (string) - Shader model for DXIL/SPIRV (always SM 5.0 for DXBC) in 'X_Y' format
+- `-m, --shaderModel` (string) - Shader model for *DXIL/SPIRV* (always SM 5.0 for *DXBC*) in 'X_Y' format
 - `-O, --optimization` (int) - Optimization level 0-3 (default = 3, disabled = 0)
 - `-X, --compilerOptions` (string) - Custom command line options for the compiler, separated by spaces
-- `--WX` - Maps to '-WX' DXC/FXC option: warnings are errors
-- `--allResourcesBound` - Maps to `-all_resources_bound` DXC/FXC option: all resources bound
+- `--WX` - Maps to '-WX' *DXC/FXC* option: warnings are errors
+- `--allResourcesBound` - Maps to `-all_resources_bound` *DXC/FXC* option: all resources bound
 - `--PDB` - Output PDB files in `out/PDB/` folder
 - `--embedPDB`- Embed PDB with the shader binary
-- `--stripReflection` - Maps to `-Qstrip_reflect` DXC/FXC option: strip reflection information from a shader binary
-- `--matrixRowMajor` - Maps to `-Zpr` DXC/FXC option: pack matrices in row-major order
-- `--hlsl2021` - Maps to `-HV 2021` DXC option: enable HLSL 2021 standard
-- `--slang` - Use Slang for compilation, requires `--compiler` to specify a path to `slangc` executable
-- `--slangHLSL` - Use HLSL compatibility mode when compiler is Slang
+- `--stripReflection` - Maps to `-Qstrip_reflect` *DXC/FXC* option: strip reflection information from a shader binary
+- `--matrixRowMajor` - Maps to `-Zpr` *DXC/FXC* option: pack matrices in row-major order
+- `--hlsl2021` - Maps to `-HV 2021` *DXC* option: enable HLSL 2021 standard
+- `--slang` - Use *Slang* for compilation, requires `--compiler` to specify a path to `slangc` executable
+- `--slangHLSL` - Use HLSL compatibility mode when compiler is *Slang*
 
 Defines & include directories:
 - `-I, --include` (string) - Include directory(s)
@@ -70,14 +77,14 @@ Other options:
 - `--retryCount` - Retry count for compilation task sub-process failures
 - `--ignoreConfigDir` - Use 'current dir' instead of 'config dir' as parent path for relative dirs
 
-SPIRV options:
-- `--vulkanMemoryLayout` (string) - Maps to `-fvk-use-<VALUE>-layout` DXC options: dx, gl, scalar
+*SPIRV* options:
+- `--vulkanMemoryLayout` (string) - Maps to `-fvk-use-<VALUE>-layout` *DXC* options: dx, gl, scalar
 - `--vulkanVersion` (string) - Vulkan environment version, maps to `-fspv-target-env` (default = 1.3)
-- `--spirvExt` (string) - Maps to `-fspv-extension` option: add SPIR-V extension permitted to use
-- `--sRegShift` (int) - SPIRV: register shift for sampler (`s#`) resources
-- `--tRegShift` (int) - SPIRV: register shift for texture (`t#`) resources
-- `--bRegShift` (int) - SPIRV: register shift for constant (`b#`) resources
-- `--uRegShift` (int) - SPIRV: register shift for UAV (`u#`) resources
+- `--spirvExt` (string) - Maps to `-fspv-extension` option: add *SPIRV* extension permitted to use
+- `--sRegShift` (int) - register shift for sampler (`s#`) resources
+- `--tRegShift` (int) - register shift for texture (`t#`) resources
+- `--bRegShift` (int) - register shift for constant (`b#`) resources
+- `--uRegShift` (int) - register shift for UAV (`u#`) resources
 - `--noRegShifts` - Don't specify any register shifts for the compiler
 
 ## Config file structure
@@ -104,7 +111,7 @@ where:
 - `-O, --optimization` (int, optional) - Optimization level (global setting used by default)
 - `-o, --output` (string, optional) - Output directory override
 - `-s, --outputSuffix` (string, optional) - Suffix to add before extension after filename
-- `-m, --shaderModel` (string, optional) - Shader model for DXIL/SPIRV (always SM 5.0 for DXBC) in 'X_Y' format
+- `-m, --shaderModel` (string, optional) - Shader model for *DXIL/SPIRV* (always SM 5.0 for *DXBC*) in 'X_Y' format
 
 Additionally, the config file parser supports:
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Features:
 - Outputs results in 3 formats: native binary, header file, and a [binary blob](#user-content-shader-blob-api) containing all permutations for a given shader.
 - Minimizes the number of re-compilation tasks by tracking file modification times and include trees.
 
-During project deployment, the *CMake* script automatically searches for `fxc` and `dxc` and sets these variables:
+During project deployment, the *CMake* script automatically downloads/searches for `fxc` and `dxc` and sets these variables:
 
-- `FXC_PATH` - `fxc` from *Windows SDK*
-- `DXC_PATH` - `dxc` from *Windows SDK*
-- `DXC_SPIRV_PATH` - `dxc` with enabled SPIRV generation from *Vulkan SDK*
+- `SHADERMAKE_FXC_PATH` (and `FXC_PATH`) - path to `fxc` from *Windows SDK*
+- `SHADERMAKE_DXC_PATH` (and `SHADERMAKE_DXC_PATH`) - path to `dxc` from *GitHub*
+- `SHADERMAKE_DXC_SPIRV_PATH` (and `SHADERMAKE_DXC_SPIRV_PATH`) - path to `dxc` from *Vulkan SDK* (with soft fallback to `dxc` from GitHub if requested but *Vulkan SDK* is not found)
 
 ## Command line options
 
@@ -64,7 +64,7 @@ Other options:
 - `--serial` - Disable multi-threading
 - `--flatten` - Flatten source directory structure in the output directory
 - `--continue` - Continue compilation if an error is occured
-- `--useAPI` - Use *FXC (d3dcompiler)* or *DXC (dxcompiler)* API explicitly (Windows only)
+- `--useAPI` - Use *FXC (d3dcompiler)* API explicitly (Windows only)
 - `--colorize` - Colorize console output
 - `--verbose` - Print commands before they are executed
 - `--retryCount` - Retry count for compilation task sub-process failures

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 *CMake* options:
 
 - `SHADERMAKE_FIND_FXC` - find *FXC* in installed [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) and populate `SHADERMAKE_FXC_PATH`
-- `SHADERMAKE_FIND_DXC` -  download [DXC]((https://github.com/microsoft/DirectXShaderCompiler)) from *GitHub* and populate `SHADERMAKE_DXC_PATH`
+- `SHADERMAKE_FIND_DXC` -  download [DXC](https://github.com/microsoft/DirectXShaderCompiler) from *GitHub* and populate `SHADERMAKE_DXC_PATH`
 - `SHADERMAKE_FIND_DXC_VK` - find *DXC* in installed [Vulkan SDK](https://www.lunarg.com/vulkan-sdk/) and populate `SHADERMAKE_DXC_VK_PATH` (this is the only way to get *DXC* on *MacOS* currently)
 - `SHADERMAKE_FIND_SLANG` - download [Slang](https://github.com/shader-slang/slang) from *GitHub* and populate `SHADERMAKE_SLANG_PATH`
 - `SHADERMAKE_FIND_COMPILERS` - master switch

--- a/src/ShaderMake.cpp
+++ b/src/ShaderMake.cpp
@@ -42,7 +42,6 @@ THE SOFTWARE.
 
 #ifdef _WIN32
     #include <d3dcompiler.h> // FXC
-    #include <dxcapi.h> // DXC
 
     #include <wrl/client.h>
     using Microsoft::WRL::ComPtr;
@@ -631,7 +630,7 @@ bool Options::Parse(int32_t argc, const char** argv)
             OPT_BOOLEAN(0, "serial", &serial, "Disable multi-threading", nullptr, 0, 0),
             OPT_BOOLEAN(0, "flatten", &flatten, "Flatten source directory structure in the output directory", nullptr, 0, 0),
             OPT_BOOLEAN(0, "continue", &continueOnError, "Continue compilation if an error is occured", nullptr, 0, 0),
-            OPT_BOOLEAN(0, "useAPI", &useAPI, "Use FXC (d3dcompiler) or DXC (dxcompiler) API explicitly (Windows only)", nullptr, 0, 0),
+            OPT_BOOLEAN(0, "useAPI", &useAPI, "Use FXC (d3dcompiler) API explicitly", nullptr, 0, 0),
             OPT_BOOLEAN(0, "colorize", &colorize, "Colorize console output", nullptr, 0, 0),
             OPT_BOOLEAN(0, "verbose", &verbose, "Print commands before they are executed", nullptr, 0, 0),
             OPT_INTEGER(0, "retryCount", &retryCount, "Retry count for compilation task sub-process failures", nullptr, 0, 0),
@@ -660,10 +659,6 @@ bool Options::Parse(int32_t argc, const char** argv)
     argparse_describe(&argparse, nullptr, "\nMulti-threaded shader compiling & processing tool");
     argparse_parse(&argparse, argc, argv);
     
-#ifndef _WIN32
-    useAPI = false;
-#endif
-
     if (!config)
     {
         Printf(RED "ERROR: Config file not specified!\n");
@@ -705,12 +700,6 @@ bool Options::Parse(int32_t argc, const char** argv)
         return false;
     }
     
-    if (slang && useAPI)
-    {
-        Printf(RED "ERROR: Use of Slang with --useAPI is not implemented.\n");
-        return false;
-    }
-
     if (strlen(shaderModel) != 3 || strstr(shaderModel, "."))
     {
         Printf(RED "ERROR: Shader model ('%s') must have format 'X_Y'!\n", shaderModel);
@@ -868,7 +857,7 @@ bool ConfigLine::Parse(int32_t argc, const char** argv)
 }
 
 //=====================================================================================================================
-// FXC/DXC API
+// FXC API
 //=====================================================================================================================
 #ifdef _WIN32
 
@@ -1122,268 +1111,6 @@ void FxcCompile()
         // Terminate if this shader failed and "--continue" is not set
         if (g_Terminate)
             break;
-    }
-}
-
-void DxcCompile()
-{
-    static const wchar_t* optimizationLevelRemap[] = {
-        // Note: if you're getting errors like "error C2065: 'DXC_ARG_SKIP_OPTIMIZATIONS': undeclared identifier" here,
-        // please update the Windows SDK to at least version 10.0.20348.0.
-        DXC_ARG_SKIP_OPTIMIZATIONS,
-        DXC_ARG_OPTIMIZATION_LEVEL1,
-        DXC_ARG_OPTIMIZATION_LEVEL2,
-        DXC_ARG_OPTIMIZATION_LEVEL3,
-    };
-
-    // Gather SPIRV register shifts once
-    static const wchar_t* regShiftArgs[] = {
-        L"-fvk-s-shift",
-        L"-fvk-t-shift",
-        L"-fvk-b-shift",
-        L"-fvk-u-shift",
-    };
-
-    vector<wstring> regShifts;
-    if (!g_Options.noRegShifts)
-    {
-        for (uint32_t reg = 0; reg < 4; reg++)
-        {
-            for (uint32_t space = 0; space < SPIRV_SPACES_NUM; space++)
-            {
-                wchar_t buf[64];
-
-                regShifts.push_back(regShiftArgs[reg]);
-
-                swprintf(buf, COUNT_OF(buf), L"%u", (&g_Options.sRegShift)[reg]);
-                regShifts.push_back(wstring(buf));
-
-                swprintf(buf, COUNT_OF(buf), L"%u", space);
-                regShifts.push_back(wstring(buf));
-            }
-        }
-    }
-
-    // TODO: is a global instance thread safe?
-    ComPtr<IDxcCompiler3> dxcCompiler;
-    HRESULT hr = DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(&dxcCompiler));
-    if (FAILED(hr))
-    {
-        // Print a message explaining that we cannot compile anything.
-        // This can happen when the user specifies a DXC version that is too old.
-        lock_guard<mutex> guard(g_TaskMutex);
-        static bool once = true;
-        if (once)
-        {
-            Printf(RED "ERROR: Cannot create an instance of IDxcCompiler3, HRESULT = 0x%08x (%s)\n", hr, std::system_category().message(hr).c_str());
-            once = false;
-        }
-        g_Terminate = true;
-        return;
-    }
-
-    ComPtr<IDxcUtils> dxcUtils;
-    hr = DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&dxcUtils));
-    if (FAILED(hr))
-    {
-        // Also print an error message.
-        // Not sure if this ever happens or all such cases are handled by the condition above, but let's be safe.
-        lock_guard<mutex> guard(g_TaskMutex);
-        static bool once = true;
-        if (once)
-        {
-            Printf(RED "ERROR: Cannot create an instance of IDxcUtils, HRESULT = 0x%08x (%s)\n", hr, std::system_category().message(hr).c_str());
-            once = false;
-        }
-        g_Terminate = true;
-        return;
-    }
-
-    while (!g_Terminate)
-    {
-        // Getting a task in the current thread
-        TaskData taskData;
-        {
-            lock_guard<mutex> guard(g_TaskMutex);
-            if (g_TaskData.empty())
-                return;
-
-            taskData = g_TaskData.back();
-            g_TaskData.pop_back();
-        }
-
-        // Compiling the shader
-        fs::path sourceFile = g_Options.sourceDir / taskData.source;
-        wstring wsourceFile = sourceFile.wstring();
-
-        ComPtr<IDxcBlob> codeBlob;
-        ComPtr<IDxcBlobEncoding> errorBlob;
-        bool isSucceeded = false;
-
-        ComPtr<IDxcBlobEncoding> sourceBlob;
-        hr = dxcUtils->LoadFile(wsourceFile.c_str(), nullptr, &sourceBlob);
-
-        if (SUCCEEDED(hr))
-        {
-            vector<wstring> args;
-            args.reserve(16 + (g_Options.defines.size() + taskData.defines.size() + g_Options.includeDirs.size()) * 2
-                + (g_Options.platform == SPIRV ? regShifts.size() + g_Options.spirvExtensions.size() : 0));
-
-            // Source file
-            args.push_back(wsourceFile);
-
-            // Profile
-            args.push_back(L"-T");
-            args.push_back(AnsiToWide(taskData.profile + "_" + taskData.shaderModel));
-
-            // Entry point
-            args.push_back(L"-E");
-            args.push_back(AnsiToWide(taskData.entryPoint));
-
-            // Defines
-            for (const string& define : g_Options.defines)
-            {
-                args.push_back(L"-D");
-                args.push_back(AnsiToWide(define));
-            }
-            for (const string& define : taskData.defines)
-            {
-                args.push_back(L"-D");
-                args.push_back(AnsiToWide(define));
-            }
-
-            // Include directories
-            for (const fs::path& path : g_Options.includeDirs)
-            {
-                args.push_back(L"-I");
-                args.push_back(path.wstring());
-            }
-
-            // Args
-            args.push_back(optimizationLevelRemap[taskData.optimizationLevel]);
-
-            uint32_t shaderModelIndex = (taskData.shaderModel[0] - '0') * 10 + (taskData.shaderModel[2] - '0');
-            if (shaderModelIndex >= 62)
-                args.push_back(L"-enable-16bit-types");
-
-            if (g_Options.warningsAreErrors)
-                args.push_back(DXC_ARG_WARNINGS_ARE_ERRORS);
-
-            if (g_Options.allResourcesBound)
-                args.push_back(DXC_ARG_ALL_RESOURCES_BOUND);
-
-            if (g_Options.matrixRowMajor)
-                args.push_back(DXC_ARG_PACK_MATRIX_ROW_MAJOR);
-
-            if (g_Options.hlsl2021)
-            {
-                args.push_back(L"-HV");
-                args.push_back(L"2021");
-            }
-
-            if (g_Options.pdb||g_Options.embedPdb)
-            {
-                // TODO: for SPIRV PDB can only be embedded, GetOutput(DXC_OUT_PDB) silently fails...
-                args.push_back(L"-Zi");
-                args.push_back(L"-Zsb"); // only binary code affects hash
-            }
-            
-            if (g_Options.embedPdb)
-                args.push_back(L"-Qembed_debug");
-
-            if (g_Options.platform == SPIRV)
-            {
-                args.push_back(L"-spirv");
-                args.push_back(wstring(L"-fspv-target-env=vulkan") + AnsiToWide(g_Options.vulkanVersion));
-
-                if (g_Options.vulkanMemoryLayout)
-                    args.push_back(wstring(L"-fvk-use-") + AnsiToWide(g_Options.vulkanMemoryLayout) + wstring(L"-layout"));
-
-                for (const string& ext : g_Options.spirvExtensions)
-                    args.push_back(wstring(L"-fspv-extension=") + AnsiToWide(ext));
-
-                for (const wstring& arg : regShifts)
-                    args.push_back(arg);
-            }
-            else // Not supported by SPIRV gen
-            {
-                if (g_Options.stripReflection)
-                    args.push_back(L"-Qstrip_reflect");
-            }
-
-            for (string const& options : g_Options.compilerOptions)
-            {
-                TokenizeCompilerOptions(options.c_str(), args);
-            }
-
-            // Debug output
-            if (g_Options.verbose)
-            {
-                wstringstream cmd;
-                for (const wstring& arg : args)
-                {
-                    cmd << arg;
-                    cmd << L" ";
-                }
-
-                Printf(WHITE "%ls\n", cmd.str().c_str());
-            }
-
-            // Now that args are finalized, get their C-string pointers into a vector
-            vector<const wchar_t*> argPointers;
-            argPointers.reserve(args.size());
-            for (const wstring& arg : args)
-                argPointers.push_back(arg.c_str());
-
-            // Compiling the shader
-            DxcBuffer sourceBuffer = {};
-            sourceBuffer.Ptr = sourceBlob->GetBufferPointer();
-            sourceBuffer.Size = sourceBlob->GetBufferSize();
-
-            ComPtr<IDxcIncludeHandler> pDefaultIncludeHandler;
-            dxcUtils->CreateDefaultIncludeHandler(&pDefaultIncludeHandler);
-
-            ComPtr<IDxcResult> dxcResult;
-            hr = dxcCompiler->Compile(&sourceBuffer, argPointers.data(), (uint32_t)args.size(), pDefaultIncludeHandler.Get(), IID_PPV_ARGS(&dxcResult));
-
-            if (SUCCEEDED(hr))
-                dxcResult->GetStatus(&hr);
-
-            if (dxcResult)
-            {
-                dxcResult->GetResult(&codeBlob);
-                dxcResult->GetErrorBuffer(&errorBlob);
-            }
-
-            isSucceeded = SUCCEEDED(hr) && codeBlob;
-
-            // Dump PDB
-            if (isSucceeded && g_Options.pdb)
-            {
-                ComPtr<IDxcBlob> pdb;
-                ComPtr<IDxcBlobUtf16> pdbName;
-                if (SUCCEEDED(dxcResult->GetOutput(DXC_OUT_PDB, IID_PPV_ARGS(&pdb), &pdbName)))
-                {
-                    wstring file = fs::path(taskData.outputFileWithoutExt).parent_path().wstring() + L"/" + _L(PDB_DIR) + L"/" + wstring(pdbName->GetStringPointer());
-                    FILE* fp = _wfopen(file.c_str(), L"wb");
-                    if (fp)
-                    {
-                        fwrite(pdb->GetBufferPointer(), pdb->GetBufferSize(), 1, fp);
-                        fclose(fp);
-                    }
-                }
-            }
-        }
-
-        if (g_Terminate)
-            break;
-
-        // Dump output
-        if (isSucceeded)
-            DumpShader(taskData, (uint8_t*)codeBlob->GetBufferPointer(), codeBlob->GetBufferSize());
-
-        // Update progress
-        UpdateProgress(taskData, isSucceeded, false, errorBlob ? (char*)errorBlob->GetBufferPointer() : nullptr);
     }
 }
 
@@ -2122,17 +1849,14 @@ int32_t main(int32_t argc, const char** argv)
 
     // Set envvar
     char envBuf[1024];
-    if (!g_Options.useAPI)
-    {
-        #ifdef _WIN32 // workaround for Windows
-            snprintf(envBuf, sizeof(envBuf), "COMPILER=\"%s\"", g_Options.compiler);
-        #else
-            snprintf(envBuf, sizeof(envBuf), "COMPILER=%s", g_Options.compiler);
-        #endif
+    #ifdef _WIN32 // workaround for Windows
+        snprintf(envBuf, sizeof(envBuf), "COMPILER=\"%s\"", g_Options.compiler);
+    #else
+        snprintf(envBuf, sizeof(envBuf), "COMPILER=%s", g_Options.compiler);
+    #endif
 
-        if (putenv(envBuf) != 0)
-            return 1;
-    }
+    if (putenv(envBuf) != 0)
+        return 1;
 
 #ifdef _WIN32
     // Setup a directory where to look for the compiler first
@@ -2145,10 +1869,6 @@ int32_t main(int32_t argc, const char** argv)
         char const* dllName = nullptr;
         switch (g_Options.platform)
         {
-        case DXIL:
-        case SPIRV:
-            dllName = "dxcompiler.dll";
-            break;
         case DXBC:
             dllName = "d3dcompiler_47.dll";
             break;
@@ -2242,14 +1962,12 @@ int32_t main(int32_t argc, const char** argv)
         vector<thread> threads(threadsNum);
         for (uint32_t i = 0; i < threadsNum; i++)
         {
-            if (!g_Options.useAPI)
-                threads[i] = thread(ExeCompile);
 #ifdef WIN32
-            else if (g_Options.platform == DXBC)
+            if (g_Options.useAPI && g_Options.platform == DXBC)
                 threads[i] = thread(FxcCompile);
             else
-                threads[i] = thread(DxcCompile);
 #endif
+                threads[i] = thread(ExeCompile);
         }
 
         for (uint32_t i = 0; i < threadsNum; i++)

--- a/src/ShaderMake.cpp
+++ b/src/ShaderMake.cpp
@@ -93,7 +93,7 @@ struct Options
     const char* compiler = nullptr;
     const char* outputExt = nullptr;
     const char* vulkanMemoryLayout = nullptr;
-    uint32_t sRegShift = 100; // must be first (or change "DxcCompile" code)
+    uint32_t sRegShift = 100;
     uint32_t tRegShift = 200;
     uint32_t bRegShift = 300;
     uint32_t uRegShift = 400;

--- a/src/ShaderMake.cpp
+++ b/src/ShaderMake.cpp
@@ -1980,8 +1980,8 @@ int32_t main(int32_t argc, const char** argv)
         // Dump shader blobs
         for (const auto& [blobName, blobEntries] : g_ShaderBlobs)
         {
-            // If a blob would contain one entry with no defines, just skip it:
-            // the individual file's output name is the same as the blob, and we're done here.
+            // If a blob contains one entry with no defines, just skip it.
+            // The individual file's output name is the same as the blob, and we're done here.
             if (blobEntries.size() == 1 && blobEntries[0].combinedDefines.empty())
                 continue;
 


### PR DESCRIPTION
No breaking changes:
- ShaderMake: "--useAPI" used only for FXC to get rid of zombie messages spam, silently ignored for other compilers. "DXCAPI" doesn't give anything except maintenance burden
- CMake: instead of searching for DXC in Windows SDK, download it from GitHub (if "SHADERMAKE_FIND_DXC" is ON, Linux supported too)
- CMake: ARM support
- CMake: set "DXC_SPIRV_PATH" to "DXC_PATH" if Vulkan SDK is not installed but this path is requested (downloaded DXC supports SPIRV codegen)
- CMake: in addition to now deprecated but still available "DXC_PATH" and friends added proper output variables "SHADERMAKE_DXC_PATH" and friends
- CMake: getting rid of "dxcapi" including all dependencies and logic
- CMake: removed "SHADERMAKE_SEARCH_FOR_COMPILERS" due to presence of individual options ("SHADERMAKE_FIND_FXC", "SHADERMAKE_FIND_DXC" and "SHADERMAKE_FIND_DXC_SPIRV")
- CMake: properly initialize "output" variables as "CACHE INTERNAL" to make them not appearing in GUI
- CMake: applied standard (VSCode) formatting